### PR TITLE
Update sapient_message.proto

### DIFF
--- a/bsi_flex_335_v1_0/sapient_message.proto
+++ b/bsi_flex_335_v1_0/sapient_message.proto
@@ -10,7 +10,7 @@ import "sapient_msg/bsi_flex_335_v1_0/alert.proto";
 import "sapient_msg/bsi_flex_335_v1_0/alert_ack.proto";
 import "sapient_msg/bsi_flex_335_v1_0/detection_report.proto";
 import "sapient_msg/bsi_flex_335_v1_0/error.proto";
-import "sapient_msg/bsi_flex_335_v1_0/proto_options.proto";
+import "sapient_msg/proto_options.proto";
 import "sapient_msg/bsi_flex_335_v1_0/registration.proto";
 import "sapient_msg/bsi_flex_335_v1_0/registration_ack.proto";
 import "sapient_msg/bsi_flex_335_v1_0/status_report.proto";


### PR DESCRIPTION
Update the path of proto_options.proto which need to be generic. In the case of the BSI Version 1 and BSI Version 2 co-exist in the same project, there is duplication regarding proto_options.proto definition.

It is also to be aligned with the BSI Version 2 - sapient_message.proto.